### PR TITLE
add support for a PHRASEAPP_HOST env variable

### DIFF
--- a/phraseapp/client.go
+++ b/phraseapp/client.go
@@ -45,8 +45,13 @@ func NewClient(credentials *Credentials) (*Client, error) {
 		EnableDebug()
 	}
 
-	if credentials.Host == "" {
-		client.Credentials.Host = "https://api.phraseapp.com"
+	if client.Credentials.Host == "" {
+		envHost := os.Getenv("PHRASEAPP_HOST")
+		if envHost != "" {
+			client.Credentials.Host = envHost
+		} else {
+			client.Credentials.Host = "https://api.phraseapp.com"
+		}
 	}
 
 	return client, nil


### PR DESCRIPTION
If no host is set in the credentials passed to `NewClient()`, the environment variable PHRASEAPP_HOST will be checked before falling back to the default value.
This behaviour is useful when testing locally without a configuration file, e.g. the `init` command in phraseapp-client.