### PR TITLE
Rename: Enable parsing of .phrase.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # phraseapp-go
 
-Go library for PhraseApp API v2.
+Go library for Phrase API v2.
 
 # Start using it
 
@@ -103,7 +103,7 @@ translations, err := client.TranslationsSearch("project_id", 1, 1000, &translati
 More [query options](https://developers.phrase.com/api/#translations)
 
 
-For a more complete example the wiki contains an example how to [upload files as translations](https://github.com/phrase/phraseapp-go/wiki/Sync-local-files-to-PhraseApp) to PhraseApp.
+For a more complete example the wiki contains an example how to [upload files as translations](https://github.com/phrase/phraseapp-go/wiki/Sync-local-files-to-PhraseApp) to Phrase.
 
 ## Contributing
 

--- a/phraseapp/client.go
+++ b/phraseapp/client.go
@@ -1,4 +1,4 @@
-// Package phraseapp is a library for easier usage of the PhraseApp API
+// Package phraseapp is a library for easier usage of the Phrase API
 package phraseapp
 
 import (

--- a/phraseapp/config.go
+++ b/phraseapp/config.go
@@ -1,6 +1,7 @@
 package phraseapp
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -26,21 +27,31 @@ type Config struct {
 	Sources []byte
 }
 
-const configName = ".phraseapp.yml"
+var configNames = []string{".phrase.yml", ".phraseapp.yml"}
 
-// ReadConfig reads a .phraseapp.yml config file
+// ReadConfig reads a .phrase.yml config file
 func ReadConfig() (*Config, error) {
-	cfg := &Config{}
-	rawCfg := struct{ PhraseApp *Config }{PhraseApp: cfg}
-
+	rawCfg := map[string]*Config{}
 	content, err := configContent()
 	switch {
 	case err != nil:
 		return nil, err
 	case content == nil:
-		return cfg, nil
+		return &Config{}, nil
 	default:
-		return cfg, yaml.Unmarshal(content, rawCfg)
+		err := yaml.Unmarshal(content, rawCfg)
+		if err != nil {
+			return nil, err
+		}
+
+		if _, found := rawCfg["phrase"]; found {
+			return rawCfg["phrase"], nil
+		}
+		if _, found := rawCfg["phraseapp"]; found {
+			return rawCfg["phraseapp"], nil
+		}
+
+		return nil, errors.New("'phrase' key is missing in config")
 	}
 }
 
@@ -75,17 +86,21 @@ func configPath() (string, error) {
 		return "", nil
 	}
 
-	possiblePath := filepath.Join(workingDir, configName)
-	if _, err := os.Stat(possiblePath); err == nil {
-		return possiblePath, nil
+	for _, configName := range configNames {
+		possiblePath := filepath.Join(workingDir, configName)
+		if _, err := os.Stat(possiblePath); err == nil {
+			return possiblePath, nil
+		}
 	}
 
-	possiblePath = defaultConfigDir()
-	if _, err := os.Stat(possiblePath); err != nil {
-		return "", nil
+	for _, configName := range configNames {
+		possiblePath := filepath.Join(defaultConfigDir(), configName)
+		if _, err := os.Stat(possiblePath); err == nil {
+			return possiblePath, nil
+		}
 	}
 
-	return possiblePath, nil
+	return "", nil
 }
 
 func (cfg *Config) UnmarshalYAML(unmarshal func(i interface{}) error) error {

--- a/phraseapp/config.go
+++ b/phraseapp/config.go
@@ -44,11 +44,11 @@ func ReadConfig() (*Config, error) {
 			return nil, err
 		}
 
-		if _, found := rawCfg["phrase"]; found {
-			return rawCfg["phrase"], nil
+		if cfg, found := rawCfg["phrase"]; found {
+			return cfg, nil
 		}
-		if _, found := rawCfg["phraseapp"]; found {
-			return rawCfg["phraseapp"], nil
+		if cfg, found := rawCfg["phraseapp"]; found {
+			return cfg, nil
 		}
 
 		return nil, errors.New("'phrase' key is missing in config")

--- a/phraseapp/config_test.go
+++ b/phraseapp/config_test.go
@@ -298,3 +298,30 @@ func TestConfigPath_NoConfigAvailable(t *testing.T) {
 		t.Errorf("expected path to be %q, got %q", expPath, path)
 	}
 }
+
+func TestParseConfig(t *testing.T) {
+	os.Setenv("PHRASEAPP_CONFIG", os.ExpandEnv("$GOPATH/src/github.com/phrase/phraseapp-go/testdata/config_files/.phrase.yml"))
+	defer os.Unsetenv("PHRASEAPP_CONFIG")
+	config, err := ReadConfig()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if config.Token != "123" {
+		t.Errorf("Got %s, expected %s", config.Token, "123")
+	}
+}
+
+func TestParseConfig_LegacyPhraseApp(t *testing.T) {
+	os.Setenv("PHRASEAPP_CONFIG", os.ExpandEnv("$GOPATH/src/github.com/phrase/phraseapp-go/testdata/config_files/.phraseapp.yml"))
+	defer os.Unsetenv("PHRASEAPP_CONFIG")
+	config, err := ReadConfig()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if config.Token != "123" {
+		t.Errorf("Got %s, expected %s", config.Token, "123")
+	}
+}
+

--- a/phraseapp/config_test.go
+++ b/phraseapp/config_test.go
@@ -228,6 +228,26 @@ func TestConfigPath_ConfigInCWD(t *testing.T) {
 	}
 }
 
+func TestConfigPath_ConfigPreference(t *testing.T) {
+	cwd := os.ExpandEnv("$GOPATH/src/github.com/phrase/phraseapp-go/testdata/config_files")
+
+	oldDir, _ := os.Getwd()
+	err := os.Chdir(cwd)
+	if err != nil {
+		t.Fatalf("didn't expect an error changing the working directory, got: %s", err)
+	}
+	defer os.Chdir(oldDir)
+
+	path, err := configPath()
+	if err != nil {
+		t.Fatalf("didn't expect an error, got: %s", err)
+	}
+	expPath := cwd + "/.phrase.yml"
+	if path != expPath {
+		t.Errorf("expected path to be %q, got %q", expPath, path)
+	}
+}
+
 func TestConfigPath_ConfigInHomeDir(t *testing.T) {
 	cwd := os.ExpandEnv("$GOPATH/src/github.com/phrase/phraseapp-go/testdata/empty")
 	oldDir, _ := os.Getwd()

--- a/phraseapp/config_unix.go
+++ b/phraseapp/config_unix.go
@@ -2,9 +2,8 @@ package phraseapp
 
 import (
 	"os"
-	"path/filepath"
 )
 
 func defaultConfigDir() string {
-	return filepath.Join(os.Getenv("HOME"), configName)
+	return os.Getenv("HOME")
 }

--- a/phraseapp/config_windows.go
+++ b/phraseapp/config_windows.go
@@ -8,5 +8,5 @@ import (
 )
 
 func defaultConfigDir() string {
-	return filepath.Join(os.Getenv("HomePath"), configName)
+	return os.Getenv("HomePath")
 }

--- a/phraseapp/http_cache.go
+++ b/phraseapp/http_cache.go
@@ -61,7 +61,7 @@ func newHTTPCacheClient(debug bool, config CacheConfig) (*httpCacheClient, error
 		config.CacheSizeMax = 1024 * 1024 * 100 // 100MB
 	}
 
-	cachePath := filepath.Join(config.CacheDir, "phraseapp")
+	cachePath := filepath.Join(config.CacheDir, "phrase")
 	err := os.MkdirAll(cachePath, 0755)
 	if err != nil {
 		return nil, err

--- a/testdata/config_files/.phrase.yml
+++ b/testdata/config_files/.phrase.yml
@@ -1,0 +1,6 @@
+phrase:
+  access_token: "123"
+  push:
+    sources:
+      - file: "./config/locales/<locale_name>.yml"
+

--- a/testdata/config_files/.phraseapp.yml
+++ b/testdata/config_files/.phraseapp.yml
@@ -1,0 +1,6 @@
+phraseapp:
+  access_token: "123"
+  push:
+    sources:
+      - file: "./config/locales/<locale_name>.yml"
+


### PR DESCRIPTION
Required for the client to be able to parse new .phrase.yml files and legacy .phraseapp.yml files